### PR TITLE
Add helpers functions used in deploy scripts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "react"
   ],
   "rules": {
-    "no-console": 0
+    "no-console": 0,
+    "arrow-body-style": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains shared configuration files, utility functions and code 
     
     ```json
     {
-      "extends": "./node_modules/common/tsconfig.json"
+      "extends": "./node_modules/@hollowverse/common/tsconfig.json"
     }
     ```
    Refer to each tool's documentation for more information on how to extend the configuration.

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ This repository contains shared configuration files, utility functions and code 
 
 In addition to shared configuration files, `common` also provides a set of utility functions used in multiple repositories in the Hollowverse organization for deployment and other tasks, the functions are exported from the [`./helpers`](./helpers) directory.
 
-Refer to the (`deploy.js`)[https://github.com/hollowverse/hollowverse/tree/master/deploy.s] script of [hollowverse/hollowverse](https://github.com/hollowverse/hollowverse) for examples on how to use these functions.
+Refer to the [`deploy.js`](https://github.com/hollowverse/hollowverse/tree/master/deploy.js) script of [hollowverse/hollowverse](https://github.com/hollowverse/hollowverse) for examples on how to use these functions.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,53 @@
-Common configurations for Hollowverse repos
-=============================================
+`@hollowverse/common`
+=================================================================
 
-This repository contains shared configuration files used across multiple [Hollowverse](https://github.com/hollowverse) repositories.
+This repository contains shared configuration files, utility functions and code quality scripts used across multiple [Hollowverse](https://github.com/hollowverse) repositories.
 
-It currently includes configuration files for:
+## Configuration Files
+`common` currently includes configuration files for:
 
 * TypeScript ([`tsconfig.json`](./tsconfig.json))
 * TSLint ([`tslint.json`](./tslint.json))
 * ESLint ([`.eslintrc.json`](./.eslintrc.json))
 * Stylelint ([`.stylelintrc`](./.stylelintrc))
 
-## How to use the shared configuration
+### How to use the shared configuration
 
-1. Install this package as dependency of your project using the [GitHub URL](https://github.com/hollowverse/common-config).
+1. Install this package as dependency of your project using the [GitHub URL](https://github.com/hollowverse/common).
      
      ```bash
-     yarn add https://github.com/hollowverse/common-config --dev
+     yarn add https://github.com/hollowverse/common --dev
      # or
-     npm install https://github.com/hollowverse/common-config --save-dev
+     npm install https://github.com/hollowverse/common --save-dev
      ```
 2. Install the [peer dependencies](./package.json#L7) for each of the tools used in the new project.
 3. Extend your project configuration files with the corresponding files from this package. For example, here is how to extend `tsconfig.json`:
     
     ```json
     {
-      "extends": "./node_modules/common-config/tsconfig.json"
+      "extends": "./node_modules/common/tsconfig.json"
     }
     ```
    Refer to each tool's documentation for more information on how to extend the configuration.
 4. Add properties to the configuration file to override the shared configuration as needed.
 
+## Helper Functions
+In addition to shared configuration files, `common` also provides a set of utility functions used in multiple repositories in the Hollowverse organization for deployment and other tasks:
+
+* [`decryptScripts`](./helpers/decryptScripts.js): Decrypts sensitive AES-256-CBC encrypted files using OpenSSL.
+* [`executeCommands`](./helpers/executeCommands.js): A helper function that executes shell commands or JavaScript functions.
+* [`retryCommand`](./helpers/retryCommand.js): Retries a JS or shell command multiple times before giving up.
+* [`writeEnvFile`](./helpers/writeEnvFile.js): Writes a JSON file that contains various information about App Engine configuration, including the branch name.
+
+Refer to the (`deploy.js`)[https://github.com/hollowverse/hollowverse/tree/master/deploy.s] script of [hollowverse/hollowverse](https://github.com/hollowverse/hollowverse) for examples on how to use these functions.
+
+## Code Quality Checks
+
+### `validate-file-names`
+To enforce a consistent file naming conventions, `common` exports a validation script that checks and reports file names that do not match the naming convention we use at Hollowverse.
+
+Once this package is installed, the script can be called using the following command:
+
+```
+yarn validate-file-names
+```

--- a/README.md
+++ b/README.md
@@ -32,22 +32,7 @@ This repository contains shared configuration files, utility functions and code 
 4. Add properties to the configuration file to override the shared configuration as needed.
 
 ## Helper Functions
-In addition to shared configuration files, `common` also provides a set of utility functions used in multiple repositories in the Hollowverse organization for deployment and other tasks:
 
-* [`decryptScripts`](./helpers/decryptScripts.js): Decrypts sensitive AES-256-CBC encrypted files using OpenSSL.
-* [`executeCommands`](./helpers/executeCommands.js): A helper function that executes shell commands or JavaScript functions.
-* [`retryCommand`](./helpers/retryCommand.js): Retries a JS or shell command multiple times before giving up.
-* [`writeEnvFile`](./helpers/writeEnvFile.js): Writes a JSON file that contains various information about App Engine configuration, including the branch name.
+In addition to shared configuration files, `common` also provides a set of utility functions used in multiple repositories in the Hollowverse organization for deployment and other tasks, the functions are exported from the [`./helpers`](./helpers) directory.
 
 Refer to the (`deploy.js`)[https://github.com/hollowverse/hollowverse/tree/master/deploy.s] script of [hollowverse/hollowverse](https://github.com/hollowverse/hollowverse) for examples on how to use these functions.
-
-## Code Quality Checks
-
-### `validate-file-names`
-To enforce a consistent file naming conventions, `common` exports a validation script that checks and reports file names that do not match the naming convention we use at Hollowverse.
-
-Once this package is installed, the script can be called using the following command:
-
-```
-yarn validate-file-names
-```

--- a/helpers/decryptSecrets.js
+++ b/helpers/decryptSecrets.js
@@ -24,4 +24,4 @@ module.exports = function decryptSecrets(secrets, baseDirectory = './secrets') {
       `;
     }),
   );
-}
+};

--- a/helpers/decryptSecrets.js
+++ b/helpers/decryptSecrets.js
@@ -13,7 +13,7 @@ module.exports = function decryptSecrets(baseDirectory, secrets) {
       const { password, decryptedFilename } = secret;
 
       const decryptedFilePath = path.join(baseDirectory, decryptedFilename);
-      const encryptedFilePath = path.join(baseDirectory, `${decryptedFilename}.enc`);
+      const encryptedFilePath = `${decryptedFilePath}.enc`;
 
       return `
         openssl aes-256-cbc \

--- a/helpers/decryptSecrets.js
+++ b/helpers/decryptSecrets.js
@@ -1,4 +1,3 @@
-// @ts-check
 const path = require('path');
 const executeCommands = require('./executeCommands');
 

--- a/helpers/decryptSecrets.js
+++ b/helpers/decryptSecrets.js
@@ -4,10 +4,10 @@ const executeCommands = require('./executeCommands');
 
 /**
  * Decrypts sensitive AES-256-CBC encrypted files using OpenSSL.
- * @param {string} baseDirectory The full path to the directory containing the encrypted secrets
  * @param {Array<{ password: string, decryptedFilename: string }>} secrets Array of secret definitions
+ * @param {string} baseDirectory The full path to the directory containing the encrypted secrets
  */
-module.exports = function decryptSecrets(baseDirectory, secrets) {
+module.exports = function decryptSecrets(secrets, baseDirectory = './secrets') {
   return executeCommands(
     secrets.map(secret => {
       const { password, decryptedFilename } = secret;

--- a/helpers/decryptSecrets.js
+++ b/helpers/decryptSecrets.js
@@ -1,0 +1,28 @@
+// @ts-check
+const path = require('path');
+const executeCommands = require('./executeCommands');
+
+/**
+ * Decrypts sensitive AES-256-CBC encrypted files using OpenSSL.
+ * @param {string} baseDirectory The full path to the directory containing the encrypted secrets
+ * @param {Array<{ password: string, decryptedFilename: string }>} secrets Array of secret definitions
+ */
+module.exports = function decryptSecrets(baseDirectory, secrets) {
+  return executeCommands(
+    secrets.map(secret => {
+      const { password, decryptedFilename } = secret;
+
+      const decryptedFilePath = path.join(baseDirectory, decryptedFilename);
+      const encryptedFilePath = path.join(baseDirectory, `${decryptedFilename}.enc`);
+
+      return `
+        openssl aes-256-cbc \
+          -in ${encryptedFilePath} \
+          -out ${decryptedFilePath} \
+          -d \
+          -base64 \
+          -pass pass:${password}
+      `;
+    }),
+  );
+}

--- a/helpers/executeCommands.js
+++ b/helpers/executeCommands.js
@@ -9,8 +9,6 @@ const shelljs = require('shelljs');
  * @return Exit code for the last executed command, a non-zero value indicates failure
  */
 module.exports = async function executeCommands(commands) {
-  let code = 0;
-
   for (const command of commands) {
     let code = 0;
     if (typeof command === 'function') {
@@ -29,10 +27,11 @@ module.exports = async function executeCommands(commands) {
       code = await new Promise((resolve) => shelljs.exec(shellCommand, resolve));
     }
 
+    // Return on first non-zero exit value
     if (code !== 0) {
-      break;
+      return code;
     }
   }
 
-  return code;
+  return 0;
 }

--- a/helpers/executeCommands.js
+++ b/helpers/executeCommands.js
@@ -1,0 +1,38 @@
+// @ts-check
+const shelljs = require('shelljs');
+
+/**
+ * A helper function that executes shell commands or JavaScript functions.
+ * Supports asynchronous operations.
+ * Simulates `set -e` behavior in shell, i.e. exits as soon as any commands fail
+ * @param  {(string | function(): (number))[]} commands
+ * @return Exit code for the last executed command, a non-zero value indicates failure
+ */
+module.exports = async function executeCommands(commands) {
+  let code = 0;
+
+  for (const command of commands) {
+    let code = 0;
+    if (typeof command === 'function') {
+      if (command.name) {
+        console.info(`${command.name}()`);
+      }
+      try {
+        code = await Promise.resolve(command());
+      } catch (e) {
+        console.error(e);
+        code = 1;
+      }
+    } else {
+      const shellCommand = command.replace('\n', '').replace(/\s+/g, ' ').trim();
+      console.info(shellCommand);
+      code = await new Promise((resolve) => shelljs.exec(shellCommand, resolve));
+    }
+
+    if (code !== 0) {
+      break;
+    }
+  }
+
+  return code;
+}

--- a/helpers/executeCommands.js
+++ b/helpers/executeCommands.js
@@ -5,7 +5,7 @@ const shelljs = require('shelljs');
  * A helper function that executes shell commands or JavaScript functions.
  * Supports asynchronous operations.
  * Simulates `set -e` behavior in shell, i.e. exits as soon as any commands fail
- * @param  {(string | function(): (number))[]} commands
+ * @param  {(string | function(): (number | Promise<number>))[]} commands
  * @return Exit code for the last executed command, a non-zero value indicates failure
  */
 module.exports = async function executeCommands(commands) {

--- a/helpers/executeCommands.js
+++ b/helpers/executeCommands.js
@@ -8,6 +8,7 @@ const shelljs = require('shelljs');
  * @return Exit code for the last executed command, a non-zero value indicates failure
  */
 module.exports = async function executeCommands(commands) {
+  // eslint-disable-next-line no-restricted-syntax
   for (const command of commands) {
     let code = 0;
     if (typeof command === 'function') {
@@ -15,15 +16,20 @@ module.exports = async function executeCommands(commands) {
         console.info(`${command.name}()`);
       }
       try {
+        // eslint-disable-next-line no-await-in-loop
         code = await Promise.resolve(command());
       } catch (e) {
         console.error(e);
         code = 1;
       }
     } else {
-      const shellCommand = command.replace('\n', '').replace(/\s+/g, ' ').trim();
+      const shellCommand = command
+        .replace('\n', '')
+        .replace(/\s+/g, ' ')
+        .trim();
       console.info(shellCommand);
-      code = await new Promise((resolve) => shelljs.exec(shellCommand, resolve));
+      // eslint-disable-next-line no-await-in-loop
+      code = await new Promise(resolve => shelljs.exec(shellCommand, resolve));
     }
 
     // Return on first non-zero exit value
@@ -33,4 +39,4 @@ module.exports = async function executeCommands(commands) {
   }
 
   return 0;
-}
+};

--- a/helpers/executeCommands.js
+++ b/helpers/executeCommands.js
@@ -1,4 +1,3 @@
-// @ts-check
 const shelljs = require('shelljs');
 
 /**

--- a/helpers/retryCommand.js
+++ b/helpers/retryCommand.js
@@ -1,7 +1,7 @@
 const executeCommands = require('./executeCommands');
 
 /**
- * Retries a JS or shell command multiple times before giving up
+ * Retries a JS or shell command multiple times before giving up.
  * @param {string | function(): (number | Promise<number>)} command The shell command or JavaScript function to execute, the JS function must return a number. `0` indicates success, any other value indicates failure.
  * @param {number} maxNumAttempts How many times should the `command` be retried
  */

--- a/helpers/retryCommand.js
+++ b/helpers/retryCommand.js
@@ -1,0 +1,18 @@
+const executeCommands = require('./executeCommands');
+
+/**
+ * Retries a JS or shell command multiple times before giving up
+ * @param {string | function(): (number | Promise<number>)} command The shell command or JavaScript function to execute, the JS function must return a number. `0` indicates success, any other value indicates failure.
+ * @param {number} maxNumAttempts How many times should the `command` be retried
+ */
+module.exports = async function retryCommand(command, maxNumAttempts = 5) {
+  let numAttempts = 0;
+  let code = null;
+
+  while (code !== 0 && numAttempts < maxNumAttempts) {
+    code = await executeCommands([command]);
+    numAttempts += 1;
+  }
+
+  return code;
+};

--- a/helpers/retryCommand.js
+++ b/helpers/retryCommand.js
@@ -10,6 +10,7 @@ module.exports = async function retryCommand(command, maxNumAttempts = 5) {
   let code = null;
 
   while (code !== 0 && numAttempts < maxNumAttempts) {
+    // eslint-disable-next-line no-await-in-loop
     code = await executeCommands([command]);
     numAttempts += 1;
   }

--- a/helpers/retryCommand.js
+++ b/helpers/retryCommand.js
@@ -14,5 +14,5 @@ module.exports = async function retryCommand(command, maxNumAttempts = 5) {
     numAttempts += 1;
   }
 
-  return code;
+  return code || 0;
 };

--- a/helpers/writeEnvFile.js
+++ b/helpers/writeEnvFile.js
@@ -16,11 +16,18 @@ const writeFile = promisify(fs.writeFile);
  * @param {string} path The path where the file should be written
  */
 module.exports = async function writeEnvFile(service, env, path) {
-  await writeFile(path, JSON.stringify({
-    project: env.PROJECT,
-    branch: env.BRANCH,
-    service,
-  }, undefined, 2));
+  await writeFile(
+    path,
+    JSON.stringify(
+      {
+        project: env.PROJECT,
+        branch: env.BRANCH,
+        service,
+      },
+      undefined,
+      2,
+    ),
+  );
 
   return 0;
 };

--- a/helpers/writeEnvFile.js
+++ b/helpers/writeEnvFile.js
@@ -16,13 +16,11 @@ const writeFile = promisify(fs.writeFile);
  * @param {string} path The path where the file should be written
  */
 module.exports = async function writeEnvFile(service, env, path) {
-  const env = {
-    project: PROJECT,
-    branch: BRANCH,
+  await writeFile(path, JSON.stringify({
+    project: env.PROJECT,
+    branch: env.BRANCH,
     service,
-  };
-
-  await writeFile(path, JSON.stringify(env, undefined, 2));
+  }, undefined, 2));
 
   return 0;
 };

--- a/helpers/writeEnvFile.js
+++ b/helpers/writeEnvFile.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const { promisify } = require('util');
+
+const writeFile = promisify(fs.writeFile);
+
+/**
+ * Writes a JSON file that contains various
+ * information about App Engine configuration, including the branch name.
+ *
+ * This is working around the fact that App Engine does not provide this information
+ * as environment variables for Docker-based runtimes.
+ * The file should be written on CI and deployed with the app so that it can
+ * be accessed at runtime.
+ * @param {string} service The App Engine service name to be included in the env file
+ * @param {{ BRANCH?: string, PROJECT?: string, }} env The environment object
+ * @param {string} path The path where the file should be written
+ */
+module.exports = async function writeEnvFile(service, env, path) {
+  const env = {
+    project: PROJECT,
+    branch: BRANCH,
+    service,
+  };
+
+  await writeFile(path, JSON.stringify(env, undefined, 2));
+
+  return 0;
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@hollowverse/common-config",
+  "name": "@hollowverse/common",
   "version": "1.2.0",
-  "description": "Common configurations for Hollowverse repos",
+  "description": "Common configurations and helper functions for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common-config",
   "license": "Unlicense",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,17 @@
     "**/*.{j,t}s{x,}": [
       "prettier --write --single-quote --trailing-comma all",
       "git add"
-  ],
+    ],
     "**/*.js{x,}": [
       "eslint"
     ]
+  },
+  "bin": {
+    "validate-file-names": "./validateFileNames.js"
+  },
+  "dependencies": {
+    "minimatch": "^3.0.4",
+    "shelljs": "^0.7.8"
   },
   "peerDependencies": {
     "babel-eslint": "^7.2.3",
@@ -35,13 +42,6 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.0.0",
     "typescript": "^2.4.2"
-  },
-  "dependencies": {
-    "minimatch": "^3.0.4",
-    "shelljs": "^0.7.8"
-  },
-  "bin": {
-    "validate-file-names": "./validateFileNames.js"
   },
   "devDependencies": {
     "@types/minimatch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "bin": {
     "validate-file-names": "./validateFileNames.js"
+  },
+  "devDependencies": {
+    "typescript": "^2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,15 @@
   "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",
   "scripts": {
-    "validate-files-names": "node ./validateFileNames.js",
+    "validate-file-names": "node ./validateFileNames.js",
     "check-js": "tsc --noEmit",
-    "precommit": "run-s lint-staged validate-files-names check-js"
+    "lint-staged": "lint-staged"
   },
+  "pre-commit": [
+    "check-js",
+    "validate-file-names",
+    "lint-staged"
+  ],
   "lint-staged": {
     "**/*.{j,t}s{x,}": [
       "prettier --write --single-quote --trailing-comma all",
@@ -54,8 +59,9 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",
-    "husky": "^0.14.3",
+    "lint-staged": "^4.0.3",
     "npm-run-all": "^4.0.2",
+    "pre-commit": "^1.2.2",
     "prettier": "^1.5.3",
     "tslint": "^5.5.0",
     "tslint-config-prettier": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hollowverse/common",
   "version": "1.2.0",
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
-  "repository": "https://github.com/hollowverse/common-config",
+  "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",
   "scripts": {
     "validate-files-names": "node ./validateFileNames.js",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,20 @@
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common-config",
   "license": "Unlicense",
-  "pre-commit": [
-    "tsc --no-emit",
-    "./validateFileNames"
+  "scripts": {
+    "validate-files-names": "node ./validateFileNames.js",
+    "check-js": "tsc --noEmit",
+    "precommit": "run-s lint-staged validate-files-names check-js"
+  },
+  "lint-staged": {
+    "**/*.{j,t}s{x,}": [
+      "prettier --write --single-quote --trailing-comma all",
+      "git add"
   ],
+    "**/*.js{x,}": [
+      "eslint"
+    ]
+  },
   "peerDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^4.1.1",
@@ -37,7 +47,21 @@
     "@types/minimatch": "^3.0.0",
     "@types/node": "^8.0.24",
     "@types/shelljs": "^0.7.4",
+    "babel-eslint": "^7.2.3",
+    "eslint": "^4.1.1",
+    "eslint-config-airbnb": "^15.0.2",
+    "eslint-config-prettier": "^2.3.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.1.0",
     "husky": "^0.14.3",
+    "npm-run-all": "^4.0.2",
+    "prettier": "^1.5.3",
+    "tslint": "^5.5.0",
+    "tslint-config-prettier": "^1.1.0",
+    "tslint-eslint-rules": "^4.1.1",
+    "tslint-microsoft-contrib": "^5.0.1",
+    "tslint-react": "^3.0.0",
     "typescript": "^2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hollowverse/common",
   "version": "1.2.0",
-  "description": "Common configurations and helper functions for Hollowverse repos",
+  "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common-config",
   "license": "Unlicense",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "tslint-eslint-rules": "^4.1.1",
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.0.0",
-    "typescript": "^2.4.2"
+    "typescript": "^2.4.2",
+    "prettier": "^1.5.3",
+    "lint-staged": "^4.0.3",
+    "pre-commit": "^1.2.2"
   },
   "devDependencies": {
     "@types/minimatch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "tslint-eslint-rules": "^4.1.1",
     "tslint-loader": "^3.5.3",
     "tslint-microsoft-contrib": "^5.0.1",
-    "tslint-react": "^3.0.0"
+    "tslint-react": "^3.0.0",
+    "typescript": "^2.4.2"
   },
   "dependencies": {
     "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -63,11 +63,6 @@
     "npm-run-all": "^4.0.2",
     "pre-commit": "^1.2.2",
     "prettier": "^1.5.3",
-    "tslint": "^5.5.0",
-    "tslint-config-prettier": "^1.1.0",
-    "tslint-eslint-rules": "^4.1.1",
-    "tslint-microsoft-contrib": "^5.0.1",
-    "tslint-react": "^3.0.0",
     "typescript": "^2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common-config",
   "license": "Unlicense",
+  "pre-commit": [
+    "tsc --no-emit",
+    "./validateFileNames"
+  ],
   "peerDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^4.1.1",
@@ -33,6 +37,7 @@
     "validate-file-names": "./validateFileNames.js"
   },
   "devDependencies": {
+    "husky": "^0.14.3",
     "typescript": "^2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "tslint": "^5.5.0",
     "tslint-config-prettier": "^1.1.0",
     "tslint-eslint-rules": "^4.1.1",
-    "tslint-loader": "^3.5.3",
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.0.0",
     "typescript": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "tslint-react": "^3.0.0"
   },
   "dependencies": {
-    "@types/minimatch": "^3.0.0",
-    "@types/node": "^8.0.24",
-    "@types/shelljs": "^0.7.4",
     "minimatch": "^3.0.4",
     "shelljs": "^0.7.8"
   },
@@ -37,6 +34,9 @@
     "validate-file-names": "./validateFileNames.js"
   },
   "devDependencies": {
+    "@types/minimatch": "^3.0.0",
+    "@types/node": "^8.0.24",
+    "@types/shelljs": "^0.7.4",
     "husky": "^0.14.3",
     "typescript": "^2.4.2"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
     "allowSyntheticDefaultImports": true,
   
     "strict": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
     "noEmitOnError": true,
+
     "module": "commonjs",
     "target": "es2015",
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,42 @@
 {
   "compilerOptions": {
+    // It looks like TS >= 2.3 is having issues resolving type definitions
+    // bundled with npm packages unless this is set to "node" (although it
+    // is the default since 1.7)
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+  
+    "strict": true,
+    "noEmitOnError": true,
+    "module": "commonjs",
+    "target": "es2015",
+    "skipLibCheck": false,
+    "skipDefaultLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "allowJs": true,
     "checkJs": true,
-    "maxNodeModuleJsDepth": 2,
-    "module": "commonjs",
-    "target": "es2016"
-  }
+    "sourceMap": true,
+    "maxNodeModuleJsDepth": 2, // Allow TypeScript to consume JS files in node_modules to infer types
+
+    // Do not transpile JSX with TypeScript, we will do that with Babel.
+    // This allows us to use babel-preset-react-optimize to perform optimizations
+    // on JSX. Otherwise Babel won't see any JSX and no optimizations will be applied.
+    "jsx": "react",
+
+    // Allow absolute imports from 'src' dir,
+    // e.g. `import 'file';` instead of `'../../file';`
+    // This also has to be set in `webpack.config.json`, check `resolve.modules`
+    "baseUrl": ".",
+
+    // Specifies how to resolve absolute imports relative to baseUrl
+    "paths": {
+      "*": [
+        "./*" // Try exact match
+      ]
+    }
+  },
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,14 +7,15 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
 
     "module": "commonjs",
     "target": "es2015",
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "sourceMap": true,
+
     "allowJs": true,
     "checkJs": true,
-    "sourceMap": true,
     "maxNodeModuleJsDepth": 2, // Allow TypeScript to consume JS files in node_modules to infer types
 
     // Do not transpile JSX with TypeScript, we will do that with Babel.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,11 @@
 {
   "compilerOptions": {
-    // It looks like TS >= 2.3 is having issues resolving type definitions
-    // bundled with npm packages unless this is set to "node" (although it
-    // is the default since 1.7)
-    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
   
     "strict": true,
     "noEmitOnError": true,
     "module": "commonjs",
     "target": "es2015",
-    "skipLibCheck": false,
-    "skipDefaultLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "allowJs": true,
@@ -22,7 +16,7 @@
     // Do not transpile JSX with TypeScript, we will do that with Babel.
     // This allows us to use babel-preset-react-optimize to perform optimizations
     // on JSX. Otherwise Babel won't see any JSX and no optimizations will be applied.
-    "jsx": "react",
+    "jsx": "preserve",
 
     // Allow absolute imports from 'src' dir,
     // e.g. `import 'file';` instead of `'../../file';`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,21 +16,6 @@
     // Do not transpile JSX with TypeScript, we will do that with Babel.
     // This allows us to use babel-preset-react-optimize to perform optimizations
     // on JSX. Otherwise Babel won't see any JSX and no optimizations will be applied.
-    "jsx": "preserve",
-
-    // Allow absolute imports from 'src' dir,
-    // e.g. `import 'file';` instead of `'../../file';`
-    // This also has to be set in `webpack.config.json`, check `resolve.modules`
-    "baseUrl": ".",
-
-    // Specifies how to resolve absolute imports relative to baseUrl
-    "paths": {
-      "*": [
-        "./*" // Try exact match
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules"
-  ]
+    "jsx": "preserve"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,53 +1,9 @@
 {
   "compilerOptions": {
-    // It looks like TS >= 2.3 is having issues resolving type definitions
-    // bundled with npm packages unless this is set to "node" (although it
-    // is the default since 1.7)
-    "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-  
+    "allowJs": true,
+    "checkJs": true,
+    "maxNodeModuleJsDepth": 2,
     "module": "commonjs",
-    "target": "es2015",
-    "skipLibCheck": false,
-    "skipDefaultLibCheck": true,
-    
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "strictNullChecks": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    
-    "noEmitOnError": true,
-
-    "sourceMap": true,
-    
-    "allowJs": false,
-    "checkJs": true, // Enable TS type checker for JS
-
-    // Do not transpile JSX with TypeScript, we will do that with Babel.
-    // This allows us to use babel-preset-react-optimize to perform optimizations
-    // on JSX. Otherwise Babel won't see any JSX and no optimizations will be applied.
-    "jsx": "react",
-
-    // Allow absolute imports from root directory,
-    // e.g. `import 'file';` instead of `'../../file';`
-    // This also has to be set in `webpack.config.json`, check `resolve.modules`
-
-    // Since this file will be in node_modules/common-config, we need to go
-    // up two directory levels to resolve starting from the project's root.
-    "baseUrl": "./../..",
-
-    // Specifies how to resolve absolute imports relative to baseUrl
-    "paths": {
-      "*": [
-        "./*" // Try exact match in baseUrl first
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules"
-  ]
+    "target": "es2016"
+  }
 }

--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -36,6 +36,8 @@ try {
 const files = getFiles();
 
 // Create a place to store files in violation of naming convention
+
+/** @type {Array<string>} */
 const filesInViolation = [];
 
 // Now let's go through the files to see if they violate the naming convention
@@ -83,28 +85,44 @@ if (filesInViolation.length > 0) {
 
 function getFiles() {
   // Let's only validate files managed by git
-  const { code, stdout } = shelljs.exec('git ls-files', { silent: true });
-  if (code === 0 && typeof stdout === 'string') {
+  const { stdout } = shelljs.exec('git ls-files', { silent: true });
+  if (typeof stdout === 'string') {
     return stdout.split('\n').filter(file => {
       // remove empty strings from the array and remove files in ignored paths
       return file.length !== 0 && !isIgnored(file);
     });
   } else {
-    console.error(red('Unable to read git tree, is this a git repository?'));
-    process.exit(1);
+    throw new Error('Unable to read git tree, is this a git repository?');
   }
 }
+
+/**
+ * 
+ * @param {string} filePathComponent
+ */
 function isCamelCase(filePathComponent) {
   return camelCasedFileNameRegex.test(filePathComponent);
 }
+
+/**
+ * @param {string} filePath 
+ */
 function isIgnored(filePath) {
   return ignoredPatterns.some(ignoredFileOrDirectory => {
     return minimatch(filePath, ignoredFileOrDirectory, { matchBase: true });
   });
 }
+
+/**
+ * @param {string} text 
+ */
 function red(text) {
   return `\x1b[31m${text}\x1b[0m`;
 }
+
+/**
+ * @param {string} text 
+ */
 function underline(text) {
   return `\x1b[4m${text}\x1b[0m`;
 }


### PR DESCRIPTION
This PR adds the following new functions, all located in `./helpers`:

* `decryptSecrets`
* `writeEnvFiles`
* `executeCommands`
* `retryCommand`

These are used in deploy scripts of multiple repos (`hollowverse/hollowverse`, `hollowverse/letsEncrypt`, and possibly `hollowverse/hollowbot` in the future).