### PR TITLE
Add more helpers

### DIFF
--- a/helpers/executeCommand.js
+++ b/helpers/executeCommand.js
@@ -7,7 +7,7 @@ const shelljs = require('shelljs');
  * @param  {string | function(): (number | Promise<number>)} command
  * @return Exit code for the executed command, a non-zero value indicates failure
  */
-module.exports = async function executeCommands(command) {
+module.exports = async function executeCommand(command) {
   let code = 0;
   if (typeof command === 'function') {
     if (command.name) {

--- a/helpers/executeCommand.js
+++ b/helpers/executeCommand.js
@@ -1,0 +1,29 @@
+const shelljs = require('shelljs');
+
+/**
+ * A helper function that execute a single shell command or JavaScript function.
+ * Supports asynchronous JS functions, and executes shell commands in a child process
+ * that the event loop is not blocked while executing the command.
+ * @param  {string | function(): (number | Promise<number>)} command
+ * @return Exit code for the executed command, a non-zero value indicates failure
+ */
+module.exports = async function executeCommands(command) {
+  let code = 0;
+  if (typeof command === 'function') {
+    if (command.name) {
+      console.info(`${command.name}()`);
+    }
+    try {
+      code = await Promise.resolve(command());
+    } catch (e) {
+      console.error(e);
+      code = 1;
+    }
+  } else {
+    const shellCommand = command.replace('\n', '').replace(/\s+/g, ' ').trim();
+    console.info(shellCommand);
+    code = await new Promise(resolve => shelljs.exec(shellCommand, resolve));
+  }
+
+  return code;
+};

--- a/helpers/executeCommand.js
+++ b/helpers/executeCommand.js
@@ -1,9 +1,9 @@
 const shelljs = require('shelljs');
 
 /**
- * A helper function that execute a single shell command or JavaScript function.
+ * A helper function that executes a single shell command or JavaScript function.
  * Supports asynchronous JS functions, and executes shell commands in a child process
- * that the event loop is not blocked while executing the command.
+ * so that the event loop is not blocked while executing the command.
  * @param  {string | function(): (number | Promise<number>)} command
  * @return Exit code for the executed command, a non-zero value indicates failure
  */

--- a/helpers/executeCommands.js
+++ b/helpers/executeCommands.js
@@ -1,4 +1,4 @@
-const shelljs = require('shelljs');
+const executeCommand = require('./executeCommand');
 
 /**
  * A helper function that executes shell commands or JavaScript functions.
@@ -10,27 +10,8 @@ const shelljs = require('shelljs');
 module.exports = async function executeCommands(commands) {
   // eslint-disable-next-line no-restricted-syntax
   for (const command of commands) {
-    let code = 0;
-    if (typeof command === 'function') {
-      if (command.name) {
-        console.info(`${command.name}()`);
-      }
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        code = await Promise.resolve(command());
-      } catch (e) {
-        console.error(e);
-        code = 1;
-      }
-    } else {
-      const shellCommand = command
-        .replace('\n', '')
-        .replace(/\s+/g, ' ')
-        .trim();
-      console.info(shellCommand);
-      // eslint-disable-next-line no-await-in-loop
-      code = await new Promise(resolve => shelljs.exec(shellCommand, resolve));
-    }
+    // eslint-disable-next-line no-await-in-loop
+    const code = await executeCommand(command);
 
     // Return on first non-zero exit value
     if (code !== 0) {

--- a/helpers/executeCommandsInParallel.js
+++ b/helpers/executeCommandsInParallel.js
@@ -1,0 +1,26 @@
+const executeCommand = require('./executeCommand');
+
+/**
+ * Executes JS functions or shell commands in parallel and returns 1 as soon
+ * as one command or function fails.
+ * Supports asynchronous functions.
+ * @param {(string | function(): (number | Promise<number>))[]} commands The shell commands or JavaScript functions to execute in parallel
+ * @typedef {1 | 0} ReturnCode
+ * @return {Promise<ReturnCode>} Returns `1` on failure, `0` otherwise.
+ */
+module.exports = async function executeCommandsInParallel(commands) {
+  try {
+    // Promise.all rejects as soon as one promise rejects
+    await Promise.all(
+      commands.map(async command => {
+        const code = await executeCommand(command);
+        if (code !== 0) {
+          throw new Error();
+        }
+      }),
+    );
+    return 0;
+  } catch (e) {
+    return 1;
+  }
+};


### PR DESCRIPTION
This PR extracts the logic for executing a single command into a separate module, `executeCommand`, and refactors `executeCommands` to use it internally. This is in order to reuse the code in a new helper, `executeCommandsInParallel`, which as the name implies, executes commands concurrently and fails if one command fails. This will help speed up things when building on CI by building the client and server code concurrently.