### PR TITLE
Fix node executable path

### DIFF
--- a/validateFileNames.js
+++ b/validateFileNames.js
@@ -1,4 +1,4 @@
-#! /bin/node
+#! /usr/bin/node
 
 // @ts-check
 


### PR DESCRIPTION
The path to the node executable may be different between the Linux distributions, but it looks like `/usr/bin/node` is more standard.