### PR TITLE
Rewrite command execution helpers to use JS semantics

### DIFF
--- a/helpers/decryptSecrets.js
+++ b/helpers/decryptSecrets.js
@@ -11,6 +11,13 @@ module.exports = function decryptSecrets(secrets, baseDirectory = './secrets') {
     secrets.map(secret => {
       const { password, decryptedFilename } = secret;
 
+      if (password === undefined) {
+        throw new TypeError(
+          `Decryption password for ${decryptedFilename} is undefined. ` +
+            'Make sure you are passing the correct environment variable in your deploy script',
+        );
+      }
+
       const decryptedFilePath = path.join(baseDirectory, decryptedFilename);
       const encryptedFilePath = `${decryptedFilePath}.enc`;
 

--- a/helpers/executeCommands.js
+++ b/helpers/executeCommands.js
@@ -2,22 +2,15 @@ const executeCommand = require('./executeCommand');
 
 /**
  * A helper function that executes shell commands or JavaScript functions.
- * Supports asynchronous operations.
+ * Supports asynchronous JavaScript functions.
  * Simulates `set -e` behavior in shell, i.e. exits as soon as any commands fail
- * @param  {(string | function(): (number | Promise<number>))[]} commands
+ * @param  {(string | function(): (void | Promise<void>))[]} commands
  * @return Exit code for the last executed command, a non-zero value indicates failure
  */
 module.exports = async function executeCommands(commands) {
   // eslint-disable-next-line no-restricted-syntax
   for (const command of commands) {
     // eslint-disable-next-line no-await-in-loop
-    const code = await executeCommand(command);
-
-    // Return on first non-zero exit value
-    if (code !== 0) {
-      return code;
-    }
+    await executeCommand(command);
   }
-
-  return 0;
 };

--- a/helpers/executeCommandsInParallel.js
+++ b/helpers/executeCommandsInParallel.js
@@ -4,23 +4,9 @@ const executeCommand = require('./executeCommand');
  * Executes JS functions or shell commands in parallel and returns 1 as soon
  * as one command or function fails.
  * Supports asynchronous functions.
- * @param {(string | function(): (number | Promise<number>))[]} commands The shell commands or JavaScript functions to execute in parallel
- * @typedef {1 | 0} ReturnCode
- * @return {Promise<ReturnCode>} Returns `1` on failure, `0` otherwise.
+ * @param {(string | function(): (void | Promise<void>))[]} commands The shell commands or JavaScript functions to execute in parallel
  */
 module.exports = async function executeCommandsInParallel(commands) {
-  try {
-    // Promise.all rejects as soon as one promise rejects
-    await Promise.all(
-      commands.map(async command => {
-        const code = await executeCommand(command);
-        if (code !== 0) {
-          throw new Error();
-        }
-      }),
-    );
-    return 0;
-  } catch (e) {
-    return 1;
-  }
+  // Promise.all rejects as soon as one promise rejects
+  return Promise.all(commands.map(executeCommand));
 };

--- a/helpers/retryCommand.js
+++ b/helpers/retryCommand.js
@@ -1,19 +1,22 @@
-const executeCommands = require('./executeCommands');
+const executeCommand = require('./executeCommand');
 
 /**
  * Retries a JS or shell command multiple times before giving up.
- * @param {string | function(): (number | Promise<number>)} command The shell command or JavaScript function to execute, the JS function must return a number. `0` indicates success, any other value indicates failure.
+ * @param {string | function(): (void | Promise<void>)} command The shell command or JavaScript function to execute, the JS function must return a number. `0` indicates success, any other value indicates failure.
  * @param {number} maxNumAttempts How many times should the `command` be retried
  */
 module.exports = async function retryCommand(command, maxNumAttempts = 5) {
   let numAttempts = 0;
-  let code = null;
-
-  while (code !== 0 && numAttempts < maxNumAttempts) {
-    // eslint-disable-next-line no-await-in-loop
-    code = await executeCommands([command]);
-    numAttempts += 1;
+  while (numAttempts < maxNumAttempts) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await executeCommand(command);
+      break;
+    } catch (e) {
+      numAttempts += 1;
+      if (numAttempts === maxNumAttempts) {
+        throw new Error(e);
+      }
+    }
   }
-
-  return code || 0;
 };


### PR DESCRIPTION
Instead of resolving with an exit code (and sometimes a synthetic one for JS functions):
* Resolve on success
* Reject on failure

This makes allows us to use native JS try/catch.

Also, fail if a password is `undefined` in `decryptSecrets`.