### PR TITLE
Add createZipFile helper function

### DIFF
--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -10,11 +10,16 @@ const fs = require('fs');
  * the root of the file matching the current working directory.
  * @param {string} path The full path where the ZIP file will be saved, including the
  * @param {string[]} patterns Glob patterns of files to include in the ZIP file.
+ * @param {string[] | undefined} ignore Patterns of files to ignore
  * filename and extension
  */
-module.exports = async function createZipFile(path, patterns) {
+module.exports = async function createZipFile(
+  path,
+  patterns,
+  ignore = undefined,
+) {
   const files = flatten(
-    patterns.map(pattern => glob.sync(pattern, { nodir: true })),
+    patterns.map(pattern => glob.sync(pattern, { nodir: true, ignore })),
   );
   const zipFile = new JSZip();
 

--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -9,9 +9,9 @@ const fs = require('fs');
  * The contents of the ZIP file will have the same folder structure of the specified patterns, with
  * the root of the file matching the current working directory.
  * @param {string} path The full path where the ZIP file will be saved, including the
- * @param {string[]} patterns Glob patterns of files to include in the ZIP file.
- * @param {string[] | undefined} ignore Patterns of files to ignore
  * filename and extension
+ * @param {string[]} patterns Glob patterns of files to include in the ZIP file
+ * @param {string[] | undefined} ignore Patterns of files to ignore
  */
 module.exports = async function createZipFile(
   path,

--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -1,5 +1,5 @@
 const glob = require('glob');
-const JsZip = require('jszip');
+const JSZip = require('jszip');
 const flatten = require('lodash/flatten');
 const fs = require('fs');
 
@@ -18,25 +18,10 @@ module.exports = async function createZipFile(
   patterns,
   ignore = undefined,
 ) {
-  /** @type {string[]} */
   const files = flatten(
-    await Promise.all(
-      patterns.map(
-        pattern =>
-          new Promise((resolve, reject) =>
-            glob(pattern, { nodir: true, ignore }, (err, matches) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve(matches);
-              }
-            }),
-          ),
-      ),
-    ),
+    patterns.map(pattern => glob.sync(pattern, { nodir: true, ignore })),
   );
-
-  const zipFile = new JsZip();
+  const zipFile = new JSZip();
 
   files.forEach(file =>
     zipFile.file(file, fs.createReadStream(file), { createFolders: true }),

--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 /**
  * Compresses all files that match an array of glob patterns into a ZIP file written to the
  * specified path.
- * The contents of the ZIP file will have the same folder structure of the specified patterns, with
+ * The contents of the ZIP file will have the same folder structure of the matched files, with
  * the root of the file matching the current working directory.
  * @param {string} path The full path where the ZIP file will be saved, including the
  * filename and extension

--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -13,10 +13,14 @@ const fs = require('fs');
  * filename and extension
  */
 module.exports = async function createZipFile(path, patterns) {
-  const files = flatten(patterns.map(pattern => glob.sync(pattern)));
+  const files = flatten(
+    patterns.map(pattern => glob.sync(pattern, { nodir: true })),
+  );
   const zipFile = new JSZip();
 
-  files.forEach(file => zipFile.file(file, fs.createReadStream(file)));
+  files.forEach(file =>
+    zipFile.file(file, fs.createReadStream(file), { createFolders: true }),
+  );
 
   return new Promise((resolve, reject) => {
     zipFile

--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -13,11 +13,7 @@ const fs = require('fs');
  * @param {string[]} patterns Glob patterns of files to include in the ZIP file
  * @param {string[] | undefined} ignore Patterns of files to ignore
  */
-module.exports = async function createZipFile(
-  path,
-  patterns,
-  ignore = undefined,
-) {
+module.exports = function createZipFile(path, patterns, ignore = undefined) {
   const files = flatten(
     patterns.map(pattern => glob.sync(pattern, { nodir: true, ignore })),
   );

--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -1,5 +1,5 @@
 const glob = require('glob');
-const JSZip = require('jszip');
+const JsZip = require('jszip');
 const flatten = require('lodash/flatten');
 const fs = require('fs');
 
@@ -21,7 +21,7 @@ module.exports = async function createZipFile(
   const files = flatten(
     patterns.map(pattern => glob.sync(pattern, { nodir: true, ignore })),
   );
-  const zipFile = new JSZip();
+  const zipFile = new JsZip();
 
   files.forEach(file =>
     zipFile.file(file, fs.createReadStream(file), { createFolders: true }),

--- a/helpers/createZipFile.js
+++ b/helpers/createZipFile.js
@@ -1,0 +1,29 @@
+const glob = require('glob');
+const JSZip = require('jszip');
+const flatten = require('lodash/flatten');
+const fs = require('fs');
+
+/**
+ * Compresses all files that match an array of glob patterns into a ZIP file written to the
+ * specified path.
+ * The contents of the ZIP file will have the same folder structure of the specified patterns, with
+ * the root of the file matching the current working directory.
+ * @param {string} path The full path where the ZIP file will be saved, including the
+ * @param {string[]} patterns Glob patterns of files to include in the ZIP file.
+ * filename and extension
+ */
+module.exports = async function createZipFile(path, patterns) {
+  const files = flatten(patterns.map(pattern => glob.sync(pattern)));
+  const zipFile = new JSZip();
+
+  files.forEach(file => zipFile.file(file, fs.createReadStream(file)));
+
+  return new Promise((resolve, reject) => {
+    zipFile
+      // @ts-ignore
+      .generateNodeStream({ streamFiles: true, type: 'nodebuffer' })
+      .pipe(fs.createWriteStream(path))
+      .on('finish', resolve)
+      .on('error', reject);
+  });
+};

--- a/helpers/executeCommand.js
+++ b/helpers/executeCommand.js
@@ -19,11 +19,11 @@ module.exports = function executeCommand(command) {
   const shellCommand = command.replace('\n', '').replace(/\s+/g, ' ').trim();
   console.info(shellCommand);
   return new Promise((resolve, reject) =>
-    shelljs.exec(shellCommand, (code, _, stderr) => {
+    shelljs.exec(shellCommand, (code, stdout, stderr) => {
       if (code === 0) {
         resolve();
       } else {
-        const error = new TypeError(stderr);
+        const error = new TypeError(stderr || stdout);
         reject(error);
       }
     }),

--- a/helpers/writeJsonFile.js
+++ b/helpers/writeJsonFile.js
@@ -7,6 +7,6 @@ const writeFile = promisify(fs.writeFile);
  * @param {string} path Full path to the file to be written, including the file name and extension
  * @param {any} data JavaScript object to write, must be serializable
  */
-module.exports = function writeJSONFile(path, data) {
+module.exports = function writeJsonFile(path, data) {
   return writeFile(path, JSON.stringify(data, undefined, 2));
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "validate-file-names": "./validateFileNames.js"
   },
   "dependencies": {
+    "glob": "^7.1.2",
+    "jszip": "^3.1.4",
+    "lodash": "^4.17.4",
     "minimatch": "^3.0.4",
     "shelljs": "^0.7.8"
   },
@@ -39,6 +42,9 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",
+    "lint-staged": "^4.0.3",
+    "pre-commit": "^1.2.2",
+    "prettier": "^1.5.3",
     "stylelint": "^7.12.0",
     "stylelint-config-standard": "^16.0.0",
     "stylelint-no-unsupported-browser-features": "^1.0.0",
@@ -47,12 +53,12 @@
     "tslint-eslint-rules": "^4.1.1",
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.0.0",
-    "typescript": "^2.4.2",
-    "prettier": "^1.5.3",
-    "lint-staged": "^4.0.3",
-    "pre-commit": "^1.2.2"
+    "typescript": "^2.4.2"
   },
   "devDependencies": {
+    "@types/glob": "^5.0.32",
+    "@types/jszip": "^0.0.33",
+    "@types/lodash": "^4.14.74",
     "@types/minimatch": "^3.0.0",
     "@types/node": "^8.0.24",
     "@types/shelljs": "^0.7.4",


### PR DESCRIPTION
This function will be used to package the artificats file in order to deploy to Elastic Beanstalk.

Just like the `artifacts: files` section of `buildspec.yml`, this function accepts glob patterns to add files to the output ZIP file, so we just have to copy the patterns we are already using.

This PR also renames `writeJSONFile` to follow the correct naming convention.

* [ ] Update `@types/jszip` (tracked in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19781)
* [ ] Remove `@ts-ignore`
* [x] Test locally on `hollowverse/hollowverse` and `hollowverse/hollowbot`
