### PR TITLE
Upgrade compile target to es2016

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedParameters": true,
 
     "module": "commonjs",
-    "target": "es2015",
+    "target": "es2016",
     "sourceMap": true,
 
     "allowJs": true,


### PR DESCRIPTION
According to [node.green](node.green/#ES2016), Node.js has 100% support for ES2016 since 7.5. Since we are using 8.5 across all our containers, and since webpack overrides the target for our client, it is safe to upgrade the compile target of TS to ES2016 so we transpile the scripts we run in Node.js less.