### PR TITLE
Resolve conflicting rules for array types

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -35,7 +35,6 @@
       true,
       "ignore-bound-class-methods"
     ],
-    "array-type": [true, "array-simple"],
 
     // Required so that React Styleguidist works
     "no-default-export": false,

--- a/tslint.json
+++ b/tslint.json
@@ -54,6 +54,10 @@
     "jsx-boolean-value": false,
 
     "prefer-type-cast": false,
-    "no-reserved-keywords": false
+    "no-reserved-keywords": false,
+
+    // Resolve conflicting rules for array types
+    "array-type": [true, "array-simple"],
+    "prefer-array-literal": [false]
   }
 }


### PR DESCRIPTION
tslint-microsoft-contrib has a rule (`prefer-array-literal`) that enforces using the array literal syntax (`type[]`) to declare array types, which conflicts with a built-in tslint rule that prefers `Array<>` for complex object types.