### PR TITLE
Disable "allowSyntheticDefaultImports"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
   
     "strict": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
This is causing a lot of issues in server-side code. The only case where we might need this is for the client, because Webpack knows how to interpret CommonJS exports as default ES imports.