### PR TITLE
Compile TypeScript to 2017, require Node 9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hollowverse/common",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",
@@ -72,5 +72,8 @@
     "pre-commit": "^1.2.2",
     "prettier": "^1.5.3",
     "typescript": "^2.4.2"
+  },
+  "engines": {
+    "node": ">= 9.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedParameters": true,
 
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2017",
     "sourceMap": true,
 
     "allowJs": true,


### PR DESCRIPTION
According to [node.green](http://node.green/#ES2017), Node 9.2 is 100% compatible with ES2017.

This is a major version bump because this could be a breaking change, and to avoid problems with yarn. We can gradually upgrade the dependent repositories. 