### PR TITLE
Disallow default exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hollowverse/common",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",

--- a/tslint.json
+++ b/tslint.json
@@ -49,7 +49,7 @@
     "react-tsx-curly-spacing": false,
 
     "no-any": false,
-    "jsx-boolean-value": false,
+    "jsx-boolean-value": [true, "always"],
 
     "prefer-type-cast": false,
     "no-reserved-keywords": false,

--- a/tslint.json
+++ b/tslint.json
@@ -36,8 +36,7 @@
       "ignore-bound-class-methods"
     ],
 
-    // Required so that React Styleguidist works
-    "no-default-export": false,
+    "no-default-export": true,
 
     // microsoft-tslint-contrib
     "import-name": false,


### PR DESCRIPTION
Rationale: https://blog.neufund.org/why-we-have-banned-default-exports-and-you-should-do-the-same-d51fdc2cf2ad

TL;DR:
* Better developer experience:
  * auto-import in VS Code
  * easier refactoring
* Better tree shaking in some cases

We are already using named exports almost exclusively in [https://github.com/hollowverse/hollowverse](hollowverse/hollowverse), so it makes sense to enforce this rule. Some refactoring may be required though.

This PR also re-enables that JSX boolean props do not have a value (`disabled` is preferred over `disabled={true}`).