### PR TITLE
Remove GraphQL linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,36 +6,10 @@
   ],
   "parser": "babel-eslint",
   "plugins": [
-    "react",
-    "graphql"
+    "react"
   ],
   "rules": {
     "max-len": ["error", 120],
-    "max-depth": ["error", 4],
-    "graphql/template-strings": [
-      "error",
-      {
-        "env": "literal",
-        "validators": "all"
-      }
-    ],
-    "graphql/no-deprecated-fields": [
-      "error",
-      {
-        "env": "literal"
-      }
-    ],
-    "graphql/capitalized-type-name": [
-      "error",
-      {
-        "env": "literal"
-      }
-    ],
-    "graphql/named-operations": [
-      "error",
-      {
-        "env": "literal"
-      }
-    ]
+    "max-depth": ["error", 4]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hollowverse/common",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",
@@ -36,7 +36,6 @@
     "eslint": "^4.5.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.3.0",
-    "eslint-plugin-graphql": "^1.5.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",


### PR DESCRIPTION
`eslint-graphql-plugin` expects to find a `.graphqlconfig` file in every project root, even if we are not actually using any GraphQL API in the project. I'll move the configuration back to `hollowverse/hollowverse`.