### PR TITLE
Enable esModuleInterop option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hollowverse/common",
-  "version": "3.0.1",
+  "version": "3.1.1",
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "moduleResolution": "node",
+
     "strict": true,
     "noImplicitReturns": true,
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": false,
-  
+    "esModuleInterop": true,
+    "moduleResolution": "node",
     "strict": true,
     "noImplicitReturns": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
With the introduction of TypeScript 2.7, a new option, `esModuleInterop`, was added to `tsconfig.json` which allows both CommonJS and ES modules to imported with the same import style.

Before

```typescript
// Valid, works
import defaultExport from 'esmodule';
import { namedExport } from 'esmodule';


// Invalid, CommonJS modules do not have named exports
import { namedExport } from 'commonjs';

// Invalid, CommonJS modules do not have a "default" export
import defaultExport from 'commonjs';

// Import module "namespace" object, valid, works
import * as namespace from 'commonjs';
namespace.namedExport;
namespace.default;

// Valid syntax if "allowSyntheticImports" is set to true,
// but may cause a runtime error. TypeScript won't try to make the
// import work. It expects that the conversion to an ES Module
// is handled by another tool
import defaultExport from 'commonjs';

```

With `esModuleInterop`:


```typescript
// Al of the following are valid syntax, no runtime errors.
import defaultExport from 'commonjs';
import { namedExport } from 'commonjs';
import defaultExport from 'esmodule';
import { namedExport } from 'esmodule';
```

To sum things up, this allows us to import any module the same way, regardless of whether it's an ES6 module or a CommonJS module. TypeScript will ensure the output works in both environments.