### PR TITLE
Force enable allowSyntheticDefaultImports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hollowverse/common",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
 


### PR DESCRIPTION
`esModuleInterpo` should imply `allowSyntheticDefaultImports`, but that does not seem to be the case.