### PR TITLE
Update "node" engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hollowverse/common",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Common configurations, helper functions and code quality scripts for Hollowverse repos",
   "repository": "https://github.com/hollowverse/common",
   "license": "Unlicense",
@@ -101,6 +101,6 @@
     "yarnhook": "^0.1.1"
   },
   "engines": {
-    "node": ">= 9.2"
+    "node": ">= 6.10"
   }
 }


### PR DESCRIPTION
This fixes CI for `perf-monitor`. `yarn` checks for this and refuses to install a package if it's not compatible with the current Node.js version.